### PR TITLE
feature/extract-container-data

### DIFF
--- a/src/__tests__/extract-container-data.test.ts
+++ b/src/__tests__/extract-container-data.test.ts
@@ -1,0 +1,6 @@
+import {extractContainerData} from "../extract-container-data";
+
+it('does stuff', () => {
+    console.log(extractContainerData('mark-hartmann/img-name:latest'));
+    console.log(extractContainerData('github.io/mark-hartmann/img-name'));
+});

--- a/src/__tests__/extract-container-data.test.ts
+++ b/src/__tests__/extract-container-data.test.ts
@@ -1,6 +1,77 @@
 import {extractContainerData} from "../extract-container-data";
+import {adjectives, names, uniqueNamesGenerator} from 'unique-names-generator';
 
-it('does stuff', () => {
-    console.log(extractContainerData('mark-hartmann/img-name:latest'));
-    console.log(extractContainerData('github.io/mark-hartmann/img-name'));
+const getUsername = () => {
+    return uniqueNamesGenerator({
+        dictionaries: [adjectives, names],
+        length: 2,
+        style: "lowerCase"
+    });
+};
+
+const getImageName = () => {
+    return uniqueNamesGenerator({
+        dictionaries: [adjectives, names],
+        length: 2,
+        style: "lowerCase"
+    });
+};
+
+it('extracts the username, image and explicit tag', () => {
+    const username = getUsername();
+    const imageName = getImageName();
+    const release = 'v4.34.764';
+
+    const data = `${username}/${imageName}:${release}`;
+    const extracted = extractContainerData(data);
+
+    expect(extracted.repository).not.toBeDefined();
+    expect(extracted.user).toEqual(username);
+    expect(extracted.image).toEqual(imageName);
+    expect(extracted.release).toEqual(release);
 });
+
+it('extracts the username and image but neither repo or release', () => {
+    const username = getUsername();
+    const imageName = getImageName();
+
+    const data = `${username}/${imageName}`;
+    const extracted = extractContainerData(data);
+
+    expect(extracted.repository).not.toBeDefined();
+    expect(extracted.release).not.toBeDefined();
+
+    expect(extracted.image).toEqual(imageName);
+    expect(extracted.user).toEqual(username);
+});
+
+it('extracts the repo, username and image', () => {
+    const username = getUsername();
+    const imageName = getImageName();
+    const repo = 'ghcr.io';
+
+    const data = `${repo}/${username}/${imageName}`;
+    const extracted = extractContainerData(data);
+
+    expect(extracted.release).not.toBeDefined();
+    expect(extracted.repository).toEqual(repo);
+    expect(extracted.image).toEqual(imageName);
+    expect(extracted.user).toEqual(username);
+});
+
+it('extracts the username, image and explicit tag', () => {
+    const username = getUsername();
+    const imageName = getImageName();
+    const release = 'v4.34.764';
+    const repo = 'ghcr.io';
+
+    const data = `${repo}/${username}/${imageName}:${release}`;
+    const extracted = extractContainerData(data);
+
+    expect(extracted.repository).toEqual(repo);
+    expect(extracted.user).toEqual(username);
+    expect(extracted.image).toEqual(imageName);
+    expect(extracted.release).toEqual(release);
+});
+
+it.todo('can handle DockerHub officials (only the package (+ release))');

--- a/src/__tests__/extract-container-data.test.ts
+++ b/src/__tests__/extract-container-data.test.ts
@@ -1,7 +1,7 @@
 import {extractContainerData} from "../extract-container-data";
 import {adjectives, names, uniqueNamesGenerator} from 'unique-names-generator';
 
-const getUsername = () => {
+const getAuthorName = () => {
     return uniqueNamesGenerator({
         dictionaries: [adjectives, names],
         length: 2,
@@ -17,85 +17,85 @@ const getImageName = () => {
     });
 };
 
-it('extracts the username, image and explicit tag', () => {
-    const username = getUsername();
-    const imageName = getImageName();
-    const release = 'v4.34.764';
+it('extracts the author, image and explicit tag', () => {
+    const author = getAuthorName();
+    const image = getImageName();
+    const tag = 'v4.34.764';
 
-    const data = `${username}/${imageName}:${release}`;
+    const data = `${author}/${image}:${tag}`;
     const extracted = extractContainerData(data);
 
-    expect(extracted.repository).not.toBeDefined();
-    expect(extracted.user).toEqual(username);
-    expect(extracted.image).toEqual(imageName);
-    expect(extracted.release).toEqual(release);
+    expect(extracted.registry).not.toBeDefined();
+    expect(extracted.author).toEqual(author);
+    expect(extracted.image).toEqual(image);
+    expect(extracted.tag).toEqual(tag);
 });
 
-it('extracts the username and image but neither repo or release', () => {
-    const username = getUsername();
-    const imageName = getImageName();
+it('extracts the author and image but neither registry or tag', () => {
+    const author = getAuthorName();
+    const image = getImageName();
 
-    const data = `${username}/${imageName}`;
+    const data = `${author}/${image}`;
     const extracted = extractContainerData(data);
 
-    expect(extracted.repository).not.toBeDefined();
-    expect(extracted.release).not.toBeDefined();
+    expect(extracted.registry).not.toBeDefined();
+    expect(extracted.tag).not.toBeDefined();
 
-    expect(extracted.image).toEqual(imageName);
-    expect(extracted.user).toEqual(username);
+    expect(extracted.image).toEqual(image);
+    expect(extracted.author).toEqual(author);
 });
 
-it('extracts the repo, username and image', () => {
-    const username = getUsername();
-    const imageName = getImageName();
-    const repo = 'ghcr.io';
+it('extracts the registry, author and image', () => {
+    const author = getAuthorName();
+    const image = getImageName();
+    const registry = 'ghcr.io';
 
-    const data = `${repo}/${username}/${imageName}`;
+    const data = `${registry}/${author}/${image}`;
     const extracted = extractContainerData(data);
 
-    expect(extracted.release).not.toBeDefined();
-    expect(extracted.repository).toEqual(repo);
-    expect(extracted.image).toEqual(imageName);
-    expect(extracted.user).toEqual(username);
+    expect(extracted.tag).not.toBeDefined();
+    expect(extracted.registry).toEqual(registry);
+    expect(extracted.image).toEqual(image);
+    expect(extracted.author).toEqual(author);
 });
 
-it('extracts the username, image and explicit tag', () => {
-    const username = getUsername();
-    const imageName = getImageName();
-    const release = 'v4.34.764';
-    const repo = 'ghcr.io';
+it('extracts the author, image and explicit tag', () => {
+    const author = getAuthorName();
+    const image = getImageName();
+    const tag = 'v4.34.764';
+    const registry = 'ghcr.io';
 
-    const data = `${repo}/${username}/${imageName}:${release}`;
+    const data = `${registry}/${author}/${image}:${tag}`;
     const extracted = extractContainerData(data);
 
-    expect(extracted.repository).toEqual(repo);
-    expect(extracted.user).toEqual(username);
-    expect(extracted.image).toEqual(imageName);
-    expect(extracted.release).toEqual(release);
+    expect(extracted.registry).toEqual(registry);
+    expect(extracted.author).toEqual(author);
+    expect(extracted.image).toEqual(image);
+    expect(extracted.tag).toEqual(tag);
 });
 
 it('can handle DockerHub officials (only the package name)', () => {
-    const imageName = getImageName();
+    const image = getImageName();
 
-    const data = `${imageName}`;
+    const data = `${image}`;
     const extracted = extractContainerData(data);
 
-    expect(extracted.repository).not.toBeDefined();
-    expect(extracted.user).not.toBeDefined();
-    expect(extracted.release).not.toBeDefined();
-    expect(extracted.image).toEqual(imageName);
+    expect(extracted.registry).not.toBeDefined();
+    expect(extracted.author).not.toBeDefined();
+    expect(extracted.tag).not.toBeDefined();
+    expect(extracted.image).toEqual(image);
 });
 
-it('can handle DockerHub officials (package name + release)', () => {
-    const imageName = getImageName();
-    const release = 'v4.34.764';
+it('can handle DockerHub officials (package name + tag)', () => {
+    const image = getImageName();
+    const tag = 'v4.34.764';
 
-    const data = `${imageName}:${release}`;
+    const data = `${image}:${tag}`;
     const extracted = extractContainerData(data);
 
-    expect(extracted.repository).not.toBeDefined();
-    expect(extracted.user).not.toBeDefined();
+    expect(extracted.registry).not.toBeDefined();
+    expect(extracted.author).not.toBeDefined();
 
-    expect(extracted.release).toEqual(release);
-    expect(extracted.image).toEqual(imageName);
+    expect(extracted.tag).toEqual(tag);
+    expect(extracted.image).toEqual(image);
 });

--- a/src/__tests__/extract-container-data.test.ts
+++ b/src/__tests__/extract-container-data.test.ts
@@ -74,4 +74,28 @@ it('extracts the username, image and explicit tag', () => {
     expect(extracted.release).toEqual(release);
 });
 
-it.todo('can handle DockerHub officials (only the package (+ release))');
+it('can handle DockerHub officials (only the package name)', () => {
+    const imageName = getImageName();
+
+    const data = `${imageName}`;
+    const extracted = extractContainerData(data);
+
+    expect(extracted.repository).not.toBeDefined();
+    expect(extracted.user).not.toBeDefined();
+    expect(extracted.release).not.toBeDefined();
+    expect(extracted.image).toEqual(imageName);
+});
+
+it('can handle DockerHub officials (package name + release)', () => {
+    const imageName = getImageName();
+    const release = 'v4.34.764';
+
+    const data = `${imageName}:${release}`;
+    const extracted = extractContainerData(data);
+
+    expect(extracted.repository).not.toBeDefined();
+    expect(extracted.user).not.toBeDefined();
+
+    expect(extracted.release).toEqual(release);
+    expect(extracted.image).toEqual(imageName);
+});

--- a/src/extract-container-data.ts
+++ b/src/extract-container-data.ts
@@ -6,55 +6,37 @@ export interface ContainerData {
 }
 
 const extractContainerData = (str: string): ContainerData => {
-    const regex = /(?<user>.+)\/(?<name>[\w-]+)(?<release>.+)?/gm;
 
-    let repo;
-    let user: string;
-    let image: string;
+    const registryRegex = /(.*\/)/;
+    const tagRegex = /(?<=:)(?<tag>.+)/;
+
+    const pos = str.search(tagRegex);
     let release;
+    if (pos !== -1) {
+        release = str.substring(pos);
+        str = str.substr(0, pos - 1);
+    }
 
-    let m;
-    while ((m = regex.exec(str)) !== null) {
-        // This is necessary to avoid infinite loops with zero-width matches
-        if (m.index === regex.lastIndex) {
-            regex.lastIndex++;
-        }
+    const pos2 = str.split(registryRegex);
 
-        // The result can be accessed through the `m`-variable.
-        m.forEach((match, groupIndex) => {
+    const image = pos2.pop();
+    const registry = pos2.join('');
 
-            if (groupIndex === 0) {
-                return;
-            }
-
-            switch (groupIndex) {
-                case 1:
-                    if (match.includes('/')) {
-                        const fragments = match.split('/');
-                        // @ts-ignore
-                        user = fragments.pop();
-                        repo = fragments.join('/');
-                    } else {
-                        user = match;
-                    }
-                    break;
-                case 2:
-                    image = match;
-                    break;
-                case 3:
-                    release = match ? match.replace(':', '') : undefined;
-                    break;
-            }
-        });
+    let repos;
+    let users;
+    if (registry) {
+        const fragments = registry.replace(/[\/]+$/, "").split('/');
+        users = fragments.pop();
+        repos = fragments.join('/');
     }
 
     return {
         // @ts-ignore
         image: image,
         release: release,
-        repository: repo,
+        repository: repos || undefined,
         // @ts-ignore
-        user: user,
+        user: users,
     }
 };
 

--- a/src/extract-container-data.ts
+++ b/src/extract-container-data.ts
@@ -1,0 +1,61 @@
+export interface ContainerData {
+    user: string;
+    image: string;
+    release: string|undefined;
+    repository: string|undefined;
+}
+
+const extractContainerData = (str: string): ContainerData => {
+    const regex = /(?<user>.+)\/(?<name>[\w-]+)(?<release>.+)?/gm;
+
+    let repo;
+    let user: string;
+    let image: string;
+    let release;
+
+    let m;
+    while ((m = regex.exec(str)) !== null) {
+        // This is necessary to avoid infinite loops with zero-width matches
+        if (m.index === regex.lastIndex) {
+            regex.lastIndex++;
+        }
+
+        // The result can be accessed through the `m`-variable.
+        m.forEach((match, groupIndex) => {
+
+            if (groupIndex === 0) {
+                return;
+            }
+
+            switch (groupIndex) {
+                case 1:
+                    if (match.includes('/')) {
+                        const fragments = match.split('/');
+                        // @ts-ignore
+                        user = fragments.pop();
+                        repo = fragments.join('/');
+                    } else {
+                        user = match;
+                    }
+                    break;
+                case 2:
+                    image = match;
+                    break;
+                case 3:
+                    release = match ? match.replace(':', '') : undefined;
+                    break;
+            }
+        });
+    }
+
+    return {
+        // @ts-ignore
+        image: image,
+        release: release,
+        repository: repo,
+        // @ts-ignore
+        user: user,
+    }
+};
+
+export {extractContainerData};


### PR DESCRIPTION
Adds a function to extract the author, image, tag and hosting registry out of a given string. This may be useful while testing the updateDeployment function.